### PR TITLE
fix: configure cr.yaml for GitHub Actions Pages deployment

### DIFF
--- a/cr.yaml
+++ b/cr.yaml
@@ -3,5 +3,6 @@ git-repo: helm-charts
 charts-repo-url: https://smauermann.github.io/helm-charts
 index-path: .cr-release-packages/index.yaml
 package-path: .cr-release-packages
-pages-branch: gh-pages
-pages-index-path: index.yaml
+# Don't push to gh-pages branch when using GitHub Actions Pages
+# pages-branch: gh-pages
+# pages-index-path: index.yaml


### PR DESCRIPTION
Remove gh-pages branch configuration to work with GitHub Actions Pages

🤖 Generated with [Claude Code](https://claude.ai/code)